### PR TITLE
Add check labels

### DIFF
--- a/example-event.json
+++ b/example-event.json
@@ -1,4 +1,5 @@
 {
+  "timestamp": 1460172826,
   "entity": {
     "entity_class": "agent",
     "system": {
@@ -58,7 +59,9 @@
     "metadata": {
       "name": "webserver01",
       "namespace": "default",
-      "labels": null,
+      "labels": {
+        "test_attribute": "label-value-entity1"
+      },
       "annotations": {
         "sensu.io/plugins/segp/config/path1": "value-entity1",
         "sensu.io/plugins/segp/config/path2": "2468",
@@ -106,7 +109,10 @@
     "metadata": {
       "name": "check-nginx",
       "namespace": "default",
-      "labels": null,
+      "labels": {
+        "sensu.io/managed_by": "sensuctl",
+        "test_attribute": "label-value-check1"
+      },
       "annotations": {
         "sensu.io/plugins/segp/config/path1": "value-check1",
         "sensu.io/plugins/segp/config/path2": "1357",

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"net/http"
+	"strings"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-plugins-go-library/sensu"
@@ -119,6 +120,22 @@ func sendAlert(event *corev2.Event) error {
 		environment = event.Entity.Namespace
 	}
 
+	var attributes = make(map[string]string)
+	for key, value := range event.Entity.Labels {
+		if !strings.ContainsAny(key, ".$") {
+			attributes[key] = value
+		}
+	}
+	for key, value := range event.Check.Labels {
+		if !strings.ContainsAny(key, ".$") {
+			if _, ok := attributes[key]; ok {
+				attributes[key] = attributes[key] + "/" + value
+			} else {
+				attributes[key] = value
+			}
+		}
+	}
+
 	hostname, _ := os.Hostname()
 	data := &Alert{
 		Resource: event.Entity.Name,
@@ -129,7 +146,7 @@ func sendAlert(event *corev2.Event) error {
 		Group: event.Check.Namespace,
 		Value: event.Check.State,
 		Text: event.Check.Output,
-		Attributes: event.Entity.Labels,
+		Attributes: attributes,
 		Origin: fmt.Sprintf("sensu-go/%s", hostname),
 		Type: "sensuAlert",
 		RawData: event.Entity.String(),

--- a/main.go
+++ b/main.go
@@ -121,18 +121,16 @@ func sendAlert(event *corev2.Event) error {
 	}
 
 	var attributes = make(map[string]string)
+	// Alerta does not allow periods or dollar symbols in attribute names
+	var replacer = strings.NewReplacer(".", "_", "$", "_")
 	for key, value := range event.Entity.Labels {
-		if !strings.ContainsAny(key, ".$") {
-			attributes[key] = value
-		}
+		attributes[replacer.Replace(key)] = value
 	}
 	for key, value := range event.Check.Labels {
-		if !strings.ContainsAny(key, ".$") {
-			if _, ok := attributes[key]; ok {
-				attributes[key] = attributes[key] + "/" + value
-			} else {
-				attributes[key] = value
-			}
+		if _, ok := attributes[replacer.Replace(key)]; ok {
+			attributes[replacer.Replace(key)] = attributes[replacer.Replace(key)] + "/" + value
+		} else {
+			attributes[replacer.Replace(key)] = value
 		}
 	}
 


### PR DESCRIPTION
Currently, only entity labels are added to the Alerta event's attributes.

With this change, both entity and check labels are added to the attributes.

If entity and check have the same label, the check label will be appended to the entity label with a forward slash separator.

Labels with names that contain periods or dollar signs are omitted because these characters are not allowed in Alerta attribute names.